### PR TITLE
Fixed null image bytes being returned when image is not null

### DIFF
--- a/lib/src/multi_image_picker_controller.dart
+++ b/lib/src/multi_image_picker_controller.dart
@@ -35,6 +35,7 @@ class MultiImagePickerController with ChangeNotifier {
     FilePickerResult? result = await FilePicker.platform.pickFiles(
         allowMultiple: this.maxImages > 1 ? true : false,
         type: FileType.custom,
+        withData: true,
         allowedExtensions: allowedImageTypes);
     if (result != null && result.files.isNotEmpty) {
       _addImages(result.files


### PR DESCRIPTION
Sometimes the file picker package returns null as image bytes. This is easily rectified by passing the "withData: true" argument to the file picker. This has been tested to resolve the 'Null Bytes' problems on Linux.