### PR TITLE
Replace hard coded blue color to theme primary color

### DIFF
--- a/example/lib/custom/custom_1.dart
+++ b/example/lib/custom/custom_1.dart
@@ -52,14 +52,15 @@ class _Custom1State extends State<Custom1> {
             child: Center(
               child: TextButton(
                 style: TextButton.styleFrom(
-                  backgroundColor: Colors.blue.withOpacity(0.2),
+                  backgroundColor:
+                      Theme.of(context).primaryColor.withOpacity(0.2),
                   shape: CircleBorder(),
                 ),
                 child: Padding(
                   padding: const EdgeInsets.all(10),
                   child: Icon(
                     Icons.add,
-                    color: Colors.blue,
+                    color: Theme.of(context).primaryColor,
                     size: 30,
                   ),
                 ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -166,7 +166,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.15"
+    version: "0.0.16"
   path:
     dependency: transitive
     description:

--- a/lib/src/multi_image_picker_view.dart
+++ b/lib/src/multi_image_picker_view.dart
@@ -71,8 +71,8 @@ class _MultiImagePickerViewState extends State<MultiImagePickerView> {
                     child: Center(
                       child: Text(
                         widget.addMoreButtonTitle ?? 'Add More',
-                        style: const TextStyle(
-                            color: Colors.blue,
+                        style: TextStyle(
+                            color: Theme.of(context).primaryColor,
                             fontWeight: FontWeight.w500,
                             fontSize: 16),
                       ),
@@ -98,8 +98,8 @@ class _MultiImagePickerViewState extends State<MultiImagePickerView> {
                 borderRadius: BorderRadius.circular(4),
                 child: Center(
                   child: Text(widget.addButtonTitle ?? 'ADD IMAGES',
-                      style: const TextStyle(
-                          color: Colors.blue,
+                      style: TextStyle(
+                          color: Theme.of(context).primaryColor,
                           fontWeight: FontWeight.w500,
                           fontSize: 16)),
                 ),


### PR DESCRIPTION
Replaced `Colors.blue`  instances to `Theme.of(context).primaryColor` so that this widget adapts to every app theme color