### PR TITLE
Allow http(s) URLs in ImageFile to load initial images from Web

### DIFF
--- a/example/lib/custom/initial_images_custom_example.dart
+++ b/example/lib/custom/initial_images_custom_example.dart
@@ -1,0 +1,73 @@
+import 'package:example/custom_examples.dart';
+import 'package:flutter/material.dart';
+import 'package:multi_image_picker_view/multi_image_picker_view.dart';
+
+import '../picker.dart';
+
+class InitialImagesCustomExample extends StatefulWidget {
+  const InitialImagesCustomExample({Key? key}) : super(key: key);
+
+  @override
+  State<InitialImagesCustomExample> createState() =>
+      _InitialImagesCustomExampleState();
+}
+
+class _InitialImagesCustomExampleState
+    extends State<InitialImagesCustomExample> {
+  final controller = MultiImagePickerController(
+    maxImages: 12,
+    images: [
+      ImageFile(
+        UniqueKey().toString(),
+        name: "test-image.jpg",
+        extension: "jpg",
+        path: "https://t.ly/F4XOS",
+      ),
+    ],
+    picker: (bool allowMultiple) {
+      return pickImagesUsingImagePicker(allowMultiple);
+    },
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(CustomExamples.initialImages.name),
+      ),
+      body: MultiImagePickerView(
+        controller: controller,
+        padding: const EdgeInsets.all(10),
+        builder: (context, imageFile) {
+          return DefaultDraggableItemWidget(
+            imageFile: imageFile,
+            boxDecoration:
+                BoxDecoration(borderRadius: BorderRadius.circular(20)),
+            closeButtonAlignment: Alignment.topLeft,
+            fit: BoxFit.cover,
+            closeButtonIcon:
+                const Icon(Icons.delete_rounded, color: Colors.red),
+            closeButtonBoxDecoration: null,
+            showCloseButton: true,
+            closeButtonMargin: const EdgeInsets.all(3),
+            closeButtonPadding: const EdgeInsets.all(3),
+          );
+        },
+        initialWidget: DefaultInitialWidget(
+          centerWidget: Icon(Icons.image_search_outlined,
+              color: Theme.of(context).colorScheme.secondary),
+        ),
+        addMoreButton: DefaultAddMoreWidget(
+          icon: Icon(Icons.image_search_outlined,
+              color: Theme.of(context).colorScheme.secondary),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+}

--- a/example/lib/custom_examples.dart
+++ b/example/lib/custom_examples.dart
@@ -1,6 +1,7 @@
 import 'package:example/custom/default_custom_example.dart';
 import 'package:example/custom/files_custom_example.dart';
 import 'package:example/custom/full_custom_example.dart';
+import 'package:example/custom/initial_images_custom_example.dart';
 import 'package:example/custom/selectable_custom_example.dart';
 import 'package:flutter/material.dart';
 
@@ -8,7 +9,8 @@ enum CustomExamples {
   fullCustom,
   defaultCustom,
   selectableCustom,
-  filesCustom;
+  filesCustom,
+  initialImages;
 
   String get name {
     switch (this) {
@@ -20,6 +22,8 @@ enum CustomExamples {
         return "Selectable Images";
       case CustomExamples.filesCustom:
         return "File Picker";
+      case CustomExamples.initialImages:
+        return "With Initial Images";
     }
   }
 
@@ -33,6 +37,8 @@ enum CustomExamples {
         return const SelectableCustomExample();
       case CustomExamples.filesCustom:
         return const FilesCustomExample();
+      case CustomExamples.initialImages:
+        return const InitialImagesCustomExample();
     }
   }
 }

--- a/lib/src/image_file_view/io_preview.dart
+++ b/lib/src/image_file_view/io_preview.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:multi_image_picker_view/src/image_file_view/error_preview.dart';
+
 import '../image_file.dart';
 
 class ImageFileView extends StatelessWidget {
@@ -26,14 +28,20 @@ class ImageFileView extends StatelessWidget {
         color: backgroundColor ?? Theme.of(context).colorScheme.background,
         borderRadius: borderRadius ?? BorderRadius.zero,
       ),
-      child: Image.file(
-        File(imageFile.path!),
-        fit: fit,
-        errorBuilder: errorBuilder ??
-            (context, error, stackTrace) {
-              return ErrorPreview(imageFile: imageFile);
-            },
-      ),
+      child: Uri.tryParse(imageFile.path!)?.scheme.startsWith('http') == true
+          ? Image.network(
+              imageFile.path!,
+              fit: fit,
+              errorBuilder: errorBuilder ?? _defaultErrorBuilder,
+            )
+          : Image.file(
+              File(imageFile.path!),
+              fit: fit,
+              errorBuilder: errorBuilder ?? _defaultErrorBuilder,
+            ),
     );
   }
+
+  Widget _defaultErrorBuilder(context, error, stackTrace) =>
+      ErrorPreview(imageFile: imageFile);
 }


### PR DESCRIPTION
Use case: 

- an entity has a multiple pictures field
- I want to attach pictures to that entity and save it to the backend
- when I edit the entity I want to preload the widget with existing images

It is not clear how to achieve that, since ImageFile() only supports loading images from a local file, so the only option would be to download cached images locally before creating the widget, which is inconvenient and requires to wrap the widget in a `FutureBuilder` thus making the code more complicated.

An easier option would be to load images directly from http(s) URLs, so in this patch I added support for that.

Example:

```dart
  final controller = MultiImagePickerController(
    images: [
      ImageFile(
        UniqueKey().toString(),
        name: "test-image.jpg",
        extension: "jpg",
        path: "https://t.ly/F4XOS",
      ),
    ],
    // ...
``` 

Result:

![image](https://github.com/shubham-gupta-16/multi_image_picker_view/assets/4000539/74c2a86b-4a52-4700-b073-a6a148bb7aa8)

