### PR TITLE
Custom error icons in image previews

### DIFF
--- a/example/lib/custom/initial_images_custom_example.dart
+++ b/example/lib/custom/initial_images_custom_example.dart
@@ -24,6 +24,13 @@ class _InitialImagesCustomExampleState
         path:
             "https://cc-prod.scene7.com/is/image/CCProdAuthor/What-is-Stock-Photography_P1_mobile",
       ),
+      ImageFile(
+        UniqueKey().toString(),
+        name: "test-document.pdf",
+        extension: "pdf",
+        path:
+            "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+      ),
     ],
     picker: (bool allowMultiple) {
       return pickImagesUsingImagePicker(allowMultiple);

--- a/example/lib/custom/initial_images_custom_example.dart
+++ b/example/lib/custom/initial_images_custom_example.dart
@@ -1,0 +1,73 @@
+import 'package:example/custom_examples.dart';
+import 'package:flutter/material.dart';
+import 'package:multi_image_picker_view/multi_image_picker_view.dart';
+
+import '../picker.dart';
+
+class InitialImagesCustomExample extends StatefulWidget {
+  const InitialImagesCustomExample({Key? key}) : super(key: key);
+
+  @override
+  State<InitialImagesCustomExample> createState() =>
+      _InitialImagesCustomExampleState();
+}
+
+class _InitialImagesCustomExampleState
+    extends State<InitialImagesCustomExample> {
+  final controller = MultiImagePickerController(
+    maxImages: 12,
+    images: [
+      ImageFile(
+        UniqueKey().toString(),
+        name: "test-image.jpg",
+        extension: "jpg",
+        path: "https://t.ly/F4XOS",
+      ),
+    ],
+    picker: (bool allowMultiple) {
+      return pickImagesUsingImagePicker(allowMultiple);
+    },
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(CustomExamples.initialImages.name),
+      ),
+      body: MultiImagePickerView(
+        controller: controller,
+        padding: const EdgeInsets.all(10),
+        builder: (context, imageFile) {
+          return DefaultDraggableItemWidget(
+            imageFile: imageFile,
+            boxDecoration:
+                BoxDecoration(borderRadius: BorderRadius.circular(20)),
+            closeButtonAlignment: Alignment.topLeft,
+            fit: BoxFit.cover,
+            closeButtonIcon:
+                const Icon(Icons.delete_rounded, color: Colors.red),
+            closeButtonBoxDecoration: null,
+            showCloseButton: true,
+            closeButtonMargin: const EdgeInsets.all(3),
+            closeButtonPadding: const EdgeInsets.all(3),
+          );
+        },
+        initialWidget: DefaultInitialWidget(
+          centerWidget: Icon(Icons.image_search_outlined,
+              color: Theme.of(context).colorScheme.secondary),
+        ),
+        addMoreButton: DefaultAddMoreWidget(
+          icon: Icon(Icons.image_search_outlined,
+              color: Theme.of(context).colorScheme.secondary),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+}

--- a/example/lib/custom/initial_images_custom_example.dart
+++ b/example/lib/custom/initial_images_custom_example.dart
@@ -21,7 +21,8 @@ class _InitialImagesCustomExampleState
         UniqueKey().toString(),
         name: "test-image.jpg",
         extension: "jpg",
-        path: "https://t.ly/F4XOS",
+        path:
+            "https://cc-prod.scene7.com/is/image/CCProdAuthor/What-is-Stock-Photography_P1_mobile",
       ),
     ],
     picker: (bool allowMultiple) {
@@ -41,8 +42,11 @@ class _InitialImagesCustomExampleState
         builder: (context, imageFile) {
           return DefaultDraggableItemWidget(
             imageFile: imageFile,
-            boxDecoration:
-                BoxDecoration(borderRadius: BorderRadius.circular(20)),
+            boxDecoration: const BoxDecoration(
+                borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(10),
+              topRight: Radius.circular(10),
+            )),
             closeButtonAlignment: Alignment.topLeft,
             fit: BoxFit.cover,
             closeButtonIcon:
@@ -51,6 +55,11 @@ class _InitialImagesCustomExampleState
             showCloseButton: true,
             closeButtonMargin: const EdgeInsets.all(3),
             closeButtonPadding: const EdgeInsets.all(3),
+            showDescriptionField: true,
+            descriptionFieldPadding:
+                const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+            descriptionFieldCallback: (image, descr) =>
+                debugPrint("Description of ${image.key}: $descr"),
           );
         },
         initialWidget: DefaultInitialWidget(

--- a/example/lib/custom_examples.dart
+++ b/example/lib/custom_examples.dart
@@ -1,6 +1,7 @@
 import 'package:example/custom/default_custom_example.dart';
 import 'package:example/custom/files_custom_example.dart';
 import 'package:example/custom/full_custom_example.dart';
+import 'package:example/custom/initial_images_custom_example.dart';
 import 'package:example/custom/selectable_custom_example.dart';
 import 'package:flutter/material.dart';
 
@@ -8,7 +9,8 @@ enum CustomExamples {
   fullCustom,
   defaultCustom,
   selectableCustom,
-  filesCustom;
+  filesCustom,
+  initialImages;
 
   String get name {
     switch (this) {
@@ -20,6 +22,8 @@ enum CustomExamples {
         return "Selectable Images";
       case CustomExamples.filesCustom:
         return "File Picker";
+      case CustomExamples.initialImages:
+        return "With Initial Images";
     }
   }
 
@@ -33,6 +37,8 @@ enum CustomExamples {
         return const SelectableCustomExample();
       case CustomExamples.filesCustom:
         return const FilesCustomExample();
+      case CustomExamples.initialImages:
+        return const InitialImagesCustomExample();
     }
   }
 }

--- a/lib/src/image_file_view/error_preview.dart
+++ b/lib/src/image_file_view/error_preview.dart
@@ -20,7 +20,7 @@ class ErrorPreview extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
-              Icons.find_in_page_rounded,
+              _getIcon(),
               color: Theme.of(context).colorScheme.secondary,
             ),
             const SizedBox(height: 4),
@@ -37,5 +37,20 @@ class ErrorPreview extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  IconData _getIcon() {
+    switch (imageFile.extension) {
+      case 'pdf':
+        return Icons.picture_as_pdf;
+      case 'png':
+      case 'jpg':
+      case 'jpeg':
+      case 'gif':
+      case 'webp':
+        return Icons.image;
+      default:
+        return Icons.find_in_page_rounded;
+    }
   }
 }

--- a/lib/src/image_file_view/io_preview.dart
+++ b/lib/src/image_file_view/io_preview.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:multi_image_picker_view/src/image_file_view/error_preview.dart';
+
 import '../image_file.dart';
 
 class ImageFileView extends StatelessWidget {
@@ -26,14 +28,20 @@ class ImageFileView extends StatelessWidget {
         color: backgroundColor ?? Theme.of(context).colorScheme.background,
         borderRadius: borderRadius ?? BorderRadius.zero,
       ),
-      child: Image.file(
-        File(imageFile.path!),
-        fit: fit,
-        errorBuilder: errorBuilder ??
-            (context, error, stackTrace) {
-              return ErrorPreview(imageFile: imageFile);
-            },
-      ),
+      child: Uri.tryParse(imageFile.path!)?.scheme.startsWith('http') == true
+          ? Image.network(
+              imageFile.path!,
+              fit: fit,
+              errorBuilder: errorBuilder ?? _defaultErrorBuilder,
+            )
+          : Image.file(
+              File(imageFile.path!),
+              fit: fit,
+              errorBuilder: errorBuilder ?? _defaultErrorBuilder,
+            ),
     );
   }
+
+  Widget _defaultErrorBuilder(context, error, stackTrace) =>
+      ErrorPreview(imageFile: imageFile);
 }

--- a/lib/src/widgets/default_draggable_item_widget.dart
+++ b/lib/src/widgets/default_draggable_item_widget.dart
@@ -2,11 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:multi_image_picker_view/multi_image_picker_view.dart';
 import 'package:multi_image_picker_view/src/multi_image_picker_controller_wrapper.dart';
 
-import '../image_file.dart';
-import '../image_file_view/image_file_view.dart';
+typedef DescriptionFieldCallback = Function(ImageFile, String);
 
 class DefaultDraggableItemWidget extends StatelessWidget {
-  const DefaultDraggableItemWidget({
+  DefaultDraggableItemWidget({
     super.key,
     required this.imageFile,
     this.fit = BoxFit.cover,
@@ -22,7 +21,19 @@ class DefaultDraggableItemWidget extends StatelessWidget {
     ),
     this.closeButtonMargin = const EdgeInsets.all(4),
     this.closeButtonPadding = const EdgeInsets.all(3),
-  });
+    this.showDescriptionField = false,
+    this.descriptionFieldText = "",
+    this.descriptionFieldReadOnly = false,
+    this.descriptionFieldHint = "Description",
+    this.descriptionFieldPadding =
+        const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+    this.descriptionFieldCallback,
+  }) {
+    descriptionController
+      ..text = descriptionFieldText
+      ..addListener(() => descriptionFieldCallback?.call(
+          imageFile, descriptionController.text));
+  }
 
   final ImageFile imageFile;
   final BoxFit fit;
@@ -33,6 +44,13 @@ class DefaultDraggableItemWidget extends StatelessWidget {
   final BoxDecoration? closeButtonBoxDecoration;
   final EdgeInsetsGeometry closeButtonMargin;
   final EdgeInsetsGeometry closeButtonPadding;
+  final TextEditingController descriptionController = TextEditingController();
+  final bool showDescriptionField;
+  final String descriptionFieldText;
+  final bool descriptionFieldReadOnly;
+  final String descriptionFieldHint;
+  final EdgeInsetsGeometry descriptionFieldPadding;
+  final DescriptionFieldCallback? descriptionFieldCallback;
 
   @override
   Widget build(BuildContext context) {
@@ -64,6 +82,25 @@ class DefaultDraggableItemWidget extends StatelessWidget {
                       child:
                           closeButtonIcon ?? const Icon(Icons.close, size: 18)),
                 ),
+              ),
+            ),
+          ),
+        if (showDescriptionField)
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+              padding: descriptionFieldPadding,
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: descriptionFieldHint,
+                  filled: true,
+                  fillColor: Colors.white70,
+                  isDense: true,
+                ),
+                readOnly: descriptionFieldReadOnly,
+                controller: descriptionController,
+                maxLines: 1,
+                style: Theme.of(context).textTheme.labelMedium,
               ),
             ),
           ),


### PR DESCRIPTION
When building the preview of a non-image file, it's useful to show the file type, such as PDF or other, so that the picker can be used to select non-image files and the preview doesn't look like an error.

![image](https://github.com/shubham-gupta-16/multi_image_picker_view/assets/4000539/e791999c-6c4f-400b-bdb0-4d0a5d92191d)