### PR TITLE
Fixed deprecated methods and classes for flutter 3.19.6

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,8 +18,8 @@ void main() {
         ),
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ButtonStyle(
-              elevation: WidgetStateProperty.all(0),
-              backgroundColor: WidgetStateProperty.all(Colors.purple.shade50)),
+              elevation: MaterialStateProperty.all(0),
+              backgroundColor: MaterialStateProperty.all(Colors.purple.shade50)),
         )),
     home: const DemoPage(),
   ));

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -252,26 +252,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -300,10 +300,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -384,10 +384,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -408,10 +408,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "13.0.0"
   win32:
     dependency: transitive
     description:
@@ -421,5 +421,5 @@ packages:
     source: hosted
     version: "5.0.3"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.2.0-0 <4.0.0"
+  flutter: ">=3.7.0"

--- a/lib/src/image_file_view/io_preview.dart
+++ b/lib/src/image_file_view/io_preview.dart
@@ -26,7 +26,7 @@ class ImageFileView extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         color: backgroundColor ??
-            Theme.of(context).colorScheme.surfaceContainerHighest,
+            Theme.of(context).colorScheme.background,
         borderRadius: borderRadius ?? BorderRadius.zero,
       ),
       child: Uri.tryParse(imageFile.path!)?.scheme.startsWith('http') == true

--- a/lib/src/image_file_view/web_preview.dart
+++ b/lib/src/image_file_view/web_preview.dart
@@ -24,7 +24,7 @@ class ImageFileView extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         color: backgroundColor ??
-            Theme.of(context).colorScheme.surfaceContainerHighest,
+            Theme.of(context).colorScheme.background,
         borderRadius: borderRadius ?? BorderRadius.zero,
       ),
       child: imageFile.path == null

--- a/lib/src/widgets/default_draggable_item_widget.dart
+++ b/lib/src/widgets/default_draggable_item_widget.dart
@@ -58,7 +58,7 @@ class DefaultDraggableItemWidget extends StatelessWidget {
                           BoxDecoration(
                             color: Theme.of(context)
                                 .colorScheme
-                                .surfaceContainerHighest
+                                .background
                                 .withOpacity(0.5),
                             shape: BoxShape.circle,
                           ),

--- a/lib/src/widgets/default_initial_widget.dart
+++ b/lib/src/widgets/default_initial_widget.dart
@@ -27,8 +27,8 @@ class DefaultInitialWidget extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          overlayColor: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.pressed)) {
+          overlayColor: MaterialStateProperty.resolveWith((states) {
+            if (states.contains(MaterialState.pressed)) {
               return Theme.of(context).colorScheme.primary.withOpacity(0.15);
             }
             return Theme.of(context).colorScheme.primary.withOpacity(0.07);

--- a/lib/src/widgets/draggable_item_ink_well.dart
+++ b/lib/src/widgets/draggable_item_ink_well.dart
@@ -8,7 +8,7 @@ class DraggableItemInkWell extends StatelessWidget {
   final Color? hoverColor;
   final Color? highlightColor;
   final Color? focusColor;
-  final WidgetStateProperty<Color?>? overlayColor;
+  final MaterialStateProperty<Color?>? overlayColor;
   final Color? splashColor;
   final InteractiveInkFeatureFactory? splashFactory;
 


### PR DESCRIPTION
for flutter 3.19.6
Fixed deprecated methods and classes
getter 'surfaceContainerHighest' isn't defined for the type 'ColorScheme'. error fixed  to colorScheme.background
Undefined name 'WidgetStateProperty'. error fixed to MaterialStateProperty
Undefined name 'WidgetState'. error fixed to MaterialState